### PR TITLE
Added basic CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contribution Guidelines
+
+Thank you for your interest in contributing to the Unity Relay Mirror Adapter!
+
+## Contributor License Agreements
+
+When you open a pull request, you will be asked to acknolwedge our Contributor
+License Agreement. We allow both individual contributions and contributions made
+on behalf of companies. We use an open source tool called CLA assistant. If you
+have any questions on our CLA, please
+[submit an issue](https://github.com/Unity-Technologies/unity-relay-mirror-adapter/issues).


### PR DESCRIPTION
**What?** Added a basic CONTRIBUTING file which references the CLA-assistant.

**Why?** The CLA-assistant must be referenced in this file when in place.

**Note:** This file should be completed by the dev team. [Here's an example (ml-agents)](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CONTRIBUTING.md).