### PR TITLE
Upgrade to Latest 2020 LTS

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.15.4",
-    "com.unity.ide.rider": "2.0.7",
-    "com.unity.ide.visualstudio": "2.0.12",
-    "com.unity.ide.vscode": "1.2.4",
+    "com.unity.collab-proxy": "1.17.2",
+    "com.unity.ide.rider": "3.0.15",
+    "com.unity.ide.visualstudio": "2.0.16",
+    "com.unity.ide.vscode": "1.2.5",
     "com.unity.jobs": "0.11.0-preview.6",
     "com.unity.services.relay": "1.0.1-pre.3",
-    "com.unity.test-framework": "1.1.29",
+    "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "0.1.21-preview",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,11 +10,10 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "1.15.4",
+      "version": "1.17.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.nuget.newtonsoft-json": "2.0.0",
         "com.unity.services.core": "1.0.1"
       },
       "url": "https://packages.unity.com"
@@ -37,16 +36,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "2.0.7",
+      "version": "3.0.15",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.12",
+      "version": "2.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -55,7 +54,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.vscode": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -141,7 +140,7 @@
     },
     "com.unity.test-framework": {
       "version": "1.1.31",
-      "depth": 2,
+      "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.ext.nunit": "1.0.6",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.24f1
-m_EditorVersionWithRevision: 2020.3.24f1 (79c78de19888)
+m_EditorVersion: 2020.3.40f1
+m_EditorVersionWithRevision: 2020.3.40f1 (ba48d4efcef1)


### PR DESCRIPTION
This PR upgrades the sample to the latest 2020 LTS release at the time of creation. 
The sample now uses 2020.3.40f1. 