### PR TITLE
Update Sample Button Text for Clarity

### DIFF
--- a/Assets/Scripts/MenuUI.cs
+++ b/Assets/Scripts/MenuUI.cs
@@ -118,7 +118,7 @@ namespace UI
 
 					// Client + IP
 					GUILayout.BeginHorizontal();
-					if (GUILayout.Button("Client (DGS)"))
+					if (GUILayout.Button("Client (without Relay)"))
 					{
 						m_Manager.JoinStandardServer();
 					}
@@ -127,7 +127,7 @@ namespace UI
 
 					// Client + Relay Join Code
 					GUILayout.BeginHorizontal();
-					if (GUILayout.Button("Client (Relay)"))
+					if (GUILayout.Button("Client (with Relay)"))
 					{
 						m_Manager.JoinRelayServer();
 					}


### PR DESCRIPTION
Changed the text to `(without Relay)` and `(with Relay)` to better distinguish that one button is connecting via Unity Transport and the other connecting via Unity Transport and Unity Relay. 

Unity have approved the updated button text. 